### PR TITLE
Update isort version to 5.12.0 to try to fix the CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: trailing-whitespace  # trims trailing whitespace.
 
   - repo: https://github.com/PyCQA/isort.git
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
       - id: isort
 


### PR DESCRIPTION
The [tests](https://github.com/lorenzo-delsignore/vision-transformer/actions/runs/4941518140) of the CI failed and the update of isort could solve the problem as mentioned in home-assistant/core#86892